### PR TITLE
python: switch to Python-2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN apt-get -y update && \
         libxpm-dev \
         make \
         openssl \
-        python3-dev \
-        python3-pip \
+        python-dev \
+        python-pip \
         xlibmesa-glu-dev \
         zlib1g-dev && \
     apt-get -y autoremove && \


### PR DESCRIPTION
* Using Python-2.7 still because some libraries (e.g. hftools) are not
  Python-3 ready yet.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>