### PR TITLE
docker: compile ROOT with cxx17 and xrootd support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN git clone --quiet --depth 1 --branch v6-18-04 http://root.cern.ch/git/root.g
     cd /code && \
     mkdir _build && \
     cd _build && \
-    cmake ../root && \
+    cmake -Dcxx17=On -Dbuiltin_xrootd=On ../root && \
     cmake --build . -- -j3 && \
     cmake -P cmake_install.cmake && \
     cd / && \


### PR DESCRIPTION
* Uses higher C++ standard (was c++11, now c++17) to get better support
  for automatic deduction of return types using the "auto" specifier.

* Enables xrootd support to get easy pulling of files from EOS.

* Closes #7

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>