### PR TITLE
docker: addition of LD_LIBRARY_PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,3 +51,12 @@ RUN git clone --quiet --depth 1 --branch v6-18-04 http://root.cern.ch/git/root.g
     cmake -P cmake_install.cmake && \
     cd / && \
     rm -rf /code
+
+# Set helpful environment variables to point to local ROOT installation
+ENV CMAKE_PREFIX_PATH=/usr/local
+ENV DYLD_LIBRARY_PATH=/usr/local/lib
+ENV JUPYTER_PATH=/usr/local/etc/notebook
+ENV LD_LIBRARY_PATH=/usr/local/lib
+ENV LIBPATH=/usr/local/lib
+ENV PYTHONPATH=/usr/local/lib
+ENV SHLIB_PATH=/usr/local/lib


### PR DESCRIPTION
* Adds LD_LIBRARY_PATH and other environment variables to point to ROOT6
  libraries.  Useful for running C++ skimming code or for importing ROOT
  libraries in Python code without having to set up the environment
  variables in user containers.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>